### PR TITLE
Avoid upstream read_timeout deprecation and fix CLI install

### DIFF
--- a/baratron/driver.py
+++ b/baratron/driver.py
@@ -71,7 +71,7 @@ class CapacitanceManometer(object):
         'Heater Failure'
     ]
 
-    def __init__(self, address, timeout=1):
+    def __init__(self, address: str, timeout: float = 1.0):
         """Initialize device.
 
         Note that this constructor does not not connect. This will happen
@@ -85,7 +85,7 @@ class CapacitanceManometer(object):
         """
         self.address = f"http://{address.lstrip('http://').rstrip('/')}/ToolWeb/Cmd"
         self.session = None
-        self.timeout = timeout
+        self.Timeout = aiohttp.ClientTimeout(total=timeout)
         ids = ''.join(f'<V Name="{evid}"/>' for evid in self.evids.values())
         body = f'<PollRequest>{ids}</PollRequest>'
         self.request = {
@@ -104,7 +104,7 @@ class CapacitanceManometer(object):
 
     async def connect(self):
         """Connect with device, opening persistent session."""
-        self.session = aiohttp.ClientSession(read_timeout=self.timeout)
+        self.session = aiohttp.ClientSession(timeout=self.Timeout)
 
     async def disconnect(self):
         """Close the underlying session, if it exists."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[wheel]
+[bdist_wheel]
 universal = 1
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,4 +3,4 @@ universal = 1
 
 [flake8]
 max-complexity = 15
-max-line-length = 89
+max-line-length = 99

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,8 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Scientific/Engineering :: Human Machine Interfaces'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     packages=['baratron'],
     install_requires=['aiohttp'],
     entry_points={
-        'console_script': [('baratron = baratron:command_line')]
+        'console_scripts': [('baratron = baratron:command_line')]
     },
     license='GPLv2',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,13 @@ with open('README.md', 'r') as in_file:
 
 setup(
     name='baratron',
-    version='0.2.0',
+    version='0.3.0',
     description='Python driver for MKS eBaratron capacitance manometers.',
     url='http://github.com/numat/baratron/',
     author='Patrick Fuller',
     author_email='pat@numat-tech.com',
     packages=['baratron'],
-    install_requires=['aiohttp'],
+    install_requires=['aiohttp>=3.3'],
     entry_points={
         'console_scripts': [('baratron = baratron:command_line')]
     },


### PR DESCRIPTION
- Fix typo in `setup.py` that prevents CLI install.  Closes #4 
- Avoid [DeprecationWarning](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientTimeout) in upstream aiohttp.  This limits us to `aiohttp>=3.0` from 2018, which is fine.  Closes #3 
- Add type hints.  Technically the `timeout` parameter was being passed as an int instead of float, although this worked fine.